### PR TITLE
💡 Demo - migrate to state_beacon

### DIFF
--- a/lib/async_gap.dart
+++ b/lib/async_gap.dart
@@ -3,56 +3,44 @@ import 'dart:math';
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart' hide Provider;
 import 'package:provider/provider.dart';
-import 'package:signal_repro/async_value_holder.dart';
-import 'package:signals/signals_flutter.dart';
+import 'package:state_beacon/state_beacon.dart';
 
 // This signal is used to simulate a piece of data that can
 // change many times throughout the app's lifecycle.
-final mainSignal = signal<int>(0);
+final mainSignal = Beacon.writable(0);
 
 void main() {
   // Pretend to fetch new data from the server that other state in the
   // app should respond to.
-  Timer.periodic(const Duration(seconds: 5), (timer) {
+  Timer.periodic(const Duration(seconds: 2), (timer) {
     mainSignal.value = Random().nextInt(100);
   });
   runApp(const MainApp());
 }
 
+Future<DailyNetIncomeData> fetchData(int id) async {
+  await Future<void>.delayed(const Duration(seconds: 1));
+  return DailyNetIncomeData(
+    dailyIncome: id + Random().nextInt(100),
+    totalIncome: id + Random().nextInt(100),
+    averageNetIncome: id + Random().nextInt(100),
+  );
+}
+
 // A simple state container that exposes a signal to be displayed on the UI
 class DataHolder {
-  ReadonlySignal<AsyncValue<DailyNetIncomeData>> get data => _data.toReadonlySignal();
-  final _data = signal<AsyncValue<DailyNetIncomeData>>(const AsyncLoading());
+  final data = Beacon.derivedFuture(
+    () async => await fetchData(mainSignal.value),
+    manualStart: true,
+  );
 
   DataHolder() {
     // In lieu of something like a `StreamSignal` that automatically reevaluates
     // in response to the `signal`s accessed within changing, run an `effect`
     // that will update `_data` whenever `mainSignal` changes.
-    _observe();
-  }
 
-  void _observe() {
-    effect(() async {
-      _data.value = const AsyncLoading();
-      try {
-        // await Future<void>.delayed(const Duration(seconds: 1));
-        // Placing this `print` BEFORE the `await` will cause the UI to
-        // work as expected. As it is, the UI will not update after the first
-        // running of this `effect`.
-        // print('Effect running for ${mainSignal.value}');
-        _data.value = AsyncData(
-          DailyNetIncomeData(
-            dailyIncome: mainSignal.value + Random().nextInt(100),
-            totalIncome: mainSignal.value + Random().nextInt(100),
-            averageNetIncome: mainSignal.value + Random().nextInt(100),
-          ),
-        );
-      } catch (e) {
-        _data.value = AsyncError(e, StackTrace.current);
-      }
-    });
+    data.start(); // start the effect manually
   }
 }
 
@@ -65,18 +53,34 @@ class MainApp extends StatelessWidget {
       create: (context) => DataHolder(),
       child: MaterialApp(
         home: Scaffold(
-          body: Watch((context) {
-            final value = context.read<DataHolder>().data;
-            return AsyncValueHolder(
-              value: value.value,
-              builder: (data) => Center(
-                child: Text(
-                  value.toString(),
-                  textAlign: TextAlign.center,
-                ),
-              ),
-            );
-          }),
+          body: Builder(
+            builder: (ctx) {
+              final data = ctx.read<DataHolder>().data;
+              return switch (data.watch(ctx)) {
+                AsyncData<DailyNetIncomeData>(value: final v) => Center(
+                    child: Text(
+                      v.toString(),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                AsyncError(error: final e) => Center(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                      child: Text('Error: $e'),
+                    ),
+                  ),
+                _ => Center(
+                    // show the last valid data while loading
+                    child: data.lastData == null
+                        ? const CircularProgressIndicator()
+                        : Text(
+                            data.lastData.toString(),
+                            textAlign: TextAlign.center,
+                          ),
+                  ),
+              };
+            },
+          ),
         ),
       ),
     );
@@ -96,4 +100,9 @@ class DailyNetIncomeData extends Equatable {
 
   @override
   List<Object?> get props => [dailyIncome, totalIncome, averageNetIncome];
+
+  @override
+  String toString() {
+    return 'DailyNetIncomeData(dailyIncome: $dailyIncome, totalIncome: $totalIncome, averageNetIncome: $averageNetIncome)';
+  }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -200,6 +200,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.11.1"
+  state_beacon:
+    dependency: "direct main"
+    description:
+      name: state_beacon
+      sha256: "12f85a180dbe3b4933da38ab0b4b45a06a2565b09caac87aefcb6bf3a1b64a8b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.2"
   state_notifier:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,24 +1,25 @@
 name: signal_repro
 description: "A new Flutter project."
-publish_to: 'none'
+publish_to: "none"
 version: 0.1.0
 
 environment:
-  sdk: '>=3.2.0 <4.0.0'
+    sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
-  equatable: ^2.0.5
-  flutter:
-    sdk: flutter
-  hooks_riverpod: ^2.4.9
-  provider: ^6.1.1
-  rxdart: ^0.27.7
-  signals: ^1.4.1
+    equatable: ^2.0.5
+    flutter:
+        sdk: flutter
+    hooks_riverpod: ^2.4.9
+    provider: ^6.1.1
+    rxdart: ^0.27.7
+    signals: ^1.4.1
+    state_beacon: ^0.10.2
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
-  flutter_lints: ^2.0.0
+    flutter_test:
+        sdk: flutter
+    flutter_lints: ^2.0.0
 
 flutter:
-  uses-material-design: true
+    uses-material-design: true


### PR DESCRIPTION
This is just a demonstration of how to use the signals/beacons from the [state_beacon](https://pub.dev/packages/state_beacon) pkg. I think this is much cleaner. The `derivedFuture` would be the equivalent to `ComputedFuture`

I also added an improvement that shows the old data while new data is loading.